### PR TITLE
Set up a script to download MNIST dataset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ create_environment:
 	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
 	
 
+## Download MNIST dataset
+.PHONY: download_mnist
+download_mnist:
+	$(PYTHON_INTERPRETER) copilot_workspace_demo/dataset.py
+
 
 
 #################################################################################

--- a/copilot_workspace_demo/dataset.py
+++ b/copilot_workspace_demo/dataset.py
@@ -1,0 +1,9 @@
+import os
+import torch
+import torchvision
+
+def download_mnist():
+    data_dir = 'data/MNIST'
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir)
+    torchvision.datasets.MNIST(root=data_dir, download=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ isort
 pip
 python-dotenv
 -e .
+torch
+torchvision


### PR DESCRIPTION
Fixes #1

Add a script to download and extract the MNIST dataset.

* **Add `copilot_workspace_demo/dataset.py`**:
  - Import `os`, `torch`, and `torchvision`.
  - Define a function `download_mnist` to download and extract the MNIST dataset to `data/MNIST`.
  - Create the `data/MNIST` directory if it does not exist.
  - Use `torchvision.datasets.MNIST` to download and extract the dataset.

* **Modify `Makefile`**:
  - Add a new command `download_mnist` to run the script in `copilot_workspace_demo/dataset.py`.
  - Add a `.PHONY` target for `download_mnist`.

* **Modify `requirements.txt`**:
  - Add `torch` and `torchvision` as dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vinothpandian/copilot_workspace_demo/issues/1?shareId=b462dff3-cb2d-4193-bfa1-3e5fb174d23e).